### PR TITLE
Mv panther lights

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,11 @@ RUN apt-get update  && \
         python3-dev \
         python3-pip && \
     pip3 install \
+        apa102-pi \
         rosdep \
         vcstool && \
     git clone https://github.com/husarion/panther_ros.git src/panther_ros && \
     vcs import src < src/panther_ros/panther/panther.repos && \
-    cd src/apa102-pi && sudo python3 setup.py install && \
-    cd /ros_ws && \
     rosdep init && \
     rosdep update --rosdistro $ROS_DISTRO && \
     rosdep install --from-paths src -y -i && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,14 @@ RUN apt-get update  && \
     apt-get install -y \
         git \
         python3-dev \
-        python3-pip \
-        python3-pil && \
+        python3-pip && \
     pip3 install \
         rosdep \
-        imageio \
         vcstool && \
-    git clone https://github.com/byq77/apa102-pi.git src/apa102-pi  && \
+    git clone -b mc_panther_lights https://github.com/husarion/panther_ros.git src/panther_ros && \
+    vcs import src < src/panther_ros/panther/panther.repos && \
     cd src/apa102-pi && sudo python3 setup.py install && \
     cd /ros_ws && \
-    git clone https://github.com/husarion/panther_ros.git src/panther_ros  && \
-    vcs import src < src/panther_ros/panther/panther.repos && \
     rosdep init && \
     rosdep update --rosdistro $ROS_DISTRO && \
     rosdep install --from-paths src -y -i && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update  && \
     pip3 install \
         rosdep \
         vcstool && \
-    git clone -b mc_panther_lights https://github.com/husarion/panther_ros.git src/panther_ros && \
+    git clone -b mv_panther_lights https://github.com/husarion/panther_ros.git src/panther_ros && \
     vcs import src < src/panther_ros/panther/panther.repos && \
     cd src/apa102-pi && sudo python3 setup.py install && \
     cd /ros_ws && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update  && \
     pip3 install \
         rosdep \
         vcstool && \
-    git clone -b mv_panther_lights https://github.com/husarion/panther_ros.git src/panther_ros && \
+    git clone https://github.com/husarion/panther_ros.git src/panther_ros && \
     vcs import src < src/panther_ros/panther/panther.repos && \
     cd src/apa102-pi && sudo python3 setup.py install && \
     cd /ros_ws && \


### PR DESCRIPTION
Dockerfile update caused by moving the `panther_lights` package to the `panther_ros` repository. Added `apa102-pi` installations via `pip` and removed cloning of `panther_lights` package.