### PR TITLE
Update documentation and simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # panther-docker
-Docker image with a Panther ROS package
+Docker images dedicated to Husarion Panther ROS system and simulation.
+
+## Docker images
+
+Docker images are automatically deployed to Docker Hub. Image tag includes information about the ROS distribution, the version of the [panther_ros](https://github.com/husarion/panther_ros/tree/ros1) repository, and the date of release. Stable image versions are additionally tagged with `stable` and are recommended for production use.
+Below, you can find a list of available Docker images. To access the latest tag, simply follow provided links:
+
+- [husarion/panther](https://hub.docker.com/r/husarion/panther) - ROS packages for Panther robot, 
+- [husarion/panther-gazebo](https://hub.docker.com/r/husarion/panther-gazebo) - Simulation for Panther robot in Gazebo-classic.
+
+## Updating Panther Software
+
+> NOTE:
+> latest Panther Docker images are compatible with Built-in computer OS version 1.1.0 and newer. If your operating system is older, please ensure you update it before proceeding. Follow [operating system reinstallation](https://husarion.com/manuals/panther/operating-system-reinstallation/) for more info. 
+ 
+Connect to Panther Built-in computer:
+```bash
+ssh husarion@10.15.20.2
+```
+
+Edit compose file:
+```bash
+nano compose.yaml
+```
+
+Update docker tag:
+```yaml
+  panther_ros:
+    image: husarion/panther:<newest-stable-tag> # example tag: noetic-1.0.0-20230324-stable
+```
+
+Restart docker containers:
+```bash
+docker compose up -d --force-recreate
+```
+
+## Running simulation
+
+To give Docker access to your screen run:
+```bash
+xhost local:docker
+```
+
+Depending on your hardware configuration your `compose.yaml` file may differ. For Intel and AMD users you will need the following configuration: [compose.simulation.yaml](./demo/simulation/compose.simulation.yaml).
+To launch the simulation, from the directory containing compose file run:
+```bash
+  docker compose -f compose.simulation.yaml up
+```
+
+Nvidia users have to install nvidia-docker2. Installation steps can be found [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). With nvidia-docker2 installed following compose file will be needed: [compose.simulation-gpu.yaml](./demo/simulation/compose.simulation-gpu.yaml).
+To launch the simulation, from the directory containing compose file run:
+```bash
+docker compose -f compose.simulation-gpu.yaml up
+```
+
+You can go to http://localhost:8000 on your browser and use joystick to drive Panther robot.
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Docker images dedicated to Husarion Panther ROS system and simulation.
 
 ## Docker images
 
-Docker images are automatically deployed to Docker Hub. Image tag includes information about the ROS distribution, the version of the [panther_ros](https://github.com/husarion/panther_ros/tree/ros1) repository, and the date of release. Stable image versions are additionally tagged with `stable` and are recommended for production use.
+Docker images are automatically deployed to Docker Hub. Image tag includes information about the ROS distribution, the version of the [panther_ros](https://github.com/husarion/panther_ros/tree/ros1) repository, and the date of release. Additionally stable image versions are  tagged with `stable` and recommended for production use.
 Below, you can find a list of available Docker images. To access the latest tag, simply follow provided links:
 
 - [husarion/panther](https://hub.docker.com/r/husarion/panther) - ROS packages for Panther robot, 

--- a/demo/simulation/compose.simulation-gpu.yaml
+++ b/demo/simulation/compose.simulation-gpu.yaml
@@ -1,7 +1,7 @@
 services:
 
   panther_gazebo:
-    image: husarion/panther:noetic-simulation
+    image: husarion/panther-gazebo:noetic-1.0.21-20230717
     container_name: panther_gazebo
     runtime: nvidia
     tty: true
@@ -15,10 +15,13 @@ services:
     command: roslaunch panther_gazebo panther_simulation.launch
 
   webui-ros-joystick:
-    image: husarion/webui-ros-joystick:noetic
+    image: husarion/webui-ros-joystick:noetic-0.0.1-20230324-stable
     container_name: webui-ros-joystick
     environment:
       - ROS_MASTER_URI=http://panther_gazebo:11311
     ports:
       - 8000:8000
-    command: roslaunch webui-ros-joystick panther_webui.launch --wait
+    command: >
+      roslaunch --wait
+      webui-ros-joystick panther_webui.launch 
+      e_stop:=false

--- a/demo/simulation/compose.simulation.yaml
+++ b/demo/simulation/compose.simulation.yaml
@@ -1,7 +1,7 @@
 services:
 
   panther_gazebo:
-    image: husarion/panther:noetic-simulation
+    image: husarion/panther-gazebo:noetic-1.0.21-20230717
     container_name: panther_gazebo
     environment:
       - DISPLAY
@@ -11,10 +11,13 @@ services:
     command: roslaunch panther_gazebo panther_simulation.launch
 
   webui-ros-joystick:
-    image: husarion/webui-ros-joystick:noetic
+    image: husarion/webui-ros-joystick:noetic-0.0.1-20230324-stable
     container_name: webui-ros-joystick
     environment:
       - ROS_MASTER_URI=http://panther_gazebo:11311
     ports:
       - 8000:8000
-    command: roslaunch webui-ros-joystick panther_webui.launch --wait
+    command: >
+      roslaunch --wait
+      webui-ros-joystick panther_webui.launch 
+      e_stop:=false


### PR DESCRIPTION
Added info about updating docker Panther software and running simulation. 
Image tag for simulation have to be replaced with stable tag after panther_ros release 1.1 