### PR TITLE
Change ros-docker-img-action version

### DIFF
--- a/.github/workflows/ros-docker-image.yaml
+++ b/.github/workflows/ros-docker-image.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build Docker Image
-        uses: husarion-ci/ros-docker-img-action@v0.4
+        uses: husarion-ci/ros-docker-img-action@v0.5
         with:
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token:  ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Fixes getting version number for image tag