### PR TITLE
Ros2 control groups

### DIFF
--- a/demo/compose.minimal-setup.yaml
+++ b/demo/compose.minimal-setup.yaml
@@ -16,12 +16,15 @@ services:
       - /dev/gpiochip0
       - /dev/spiled-channel1
       - /dev/spiled-channel2
+    device_cgroup_rules:
+      - 'c 189:* rmw' # USB devices
+      - 'c 254:0* rw' # gpiochip0
+      - 'c 153:* rmw' # spiled-channel1, spiled-channel2
     volumes:
-      - /dev/adc0:/dev/adc0
-      - /dev/adc1:/dev/adc1
-      - ~/.ssh/id_rsa:/root/.ssh/id_rsa
       - /run/husarion/panther_config.env:/run/husarion/panther_config.env
       - /run/husarion/panther_config.yaml:/run/husarion/panther_config.yaml
+      - /sys/bus/iio/devices:/sys/bus/iio/devices
+      - ~/.ssh/id_rsa:/root/.ssh/id_rsa
     # Realtime hardware (https://control.ros.org/master/doc/ros2_control/controller_manager/doc/userdoc.html#determinism)
     ulimits:
       rtprio:

--- a/demo/compose.minimal-setup.yaml
+++ b/demo/compose.minimal-setup.yaml
@@ -17,13 +17,13 @@ services:
       - /dev/spiled-channel1
       - /dev/spiled-channel2
     device_cgroup_rules:
-      - 'c 189:* rmw' # USB devices
-      - 'c 254:0* rw' # gpiochip0
-      - 'c 153:* rmw' # spiled-channel1, spiled-channel2
+      - 'c 189:* rmw'   # USB devices
+      - 'c 254:0 rmw'   # gpiochip0
+      - 'c 153:* rmw'   # spiled-channel1, spiled-channel2
     volumes:
       - /run/husarion/panther_config.env:/run/husarion/panther_config.env
       - /run/husarion/panther_config.yaml:/run/husarion/panther_config.yaml
-      - /sys/bus/iio/devices:/sys/bus/iio/devices
+      - /sys/bus/iio/devices:/sys/bus/iio/devices:ro    # Read-only access to IIO devices
       - ~/.ssh/id_rsa:/root/.ssh/id_rsa
     # Realtime hardware (https://control.ros.org/master/doc/ros2_control/controller_manager/doc/userdoc.html#determinism)
     ulimits:


### PR DESCRIPTION
## Changes

- Added cgroups
- Removed `adc` devices
- Added reading `/sys...` path in read-only mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specific USB devices and GPIO chips.
  - Enabled read-only access to IIO devices for enhanced device integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->