### PR TITLE
Ros2 use branch name

### DIFF
--- a/.github/workflows/ros-docker-image.yaml
+++ b/.github/workflows/ros-docker-image.yaml
@@ -4,6 +4,9 @@ name: Build/Publish ROS Docker Image
 on:
   workflow_dispatch:
     inputs:
+      panther_codebase_version:
+        description: Version of the panther_ros to be used in the docker image (branch/tag/commit).
+        required: true
       build_type:
         description: Is it a "development" or a "stable" release?
         required: true
@@ -48,13 +51,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build Docker Image
-        uses: husarion-ci/ros-docker-img-action@v0.5
+        uses: husarion-ci/ros-docker-img-action@v0.6
         with:
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           main_branch_name: ros2
           dockerfile: ${{ matrix.dockerfile }}
           repo_name: ${{ matrix.repo_name }}
+          branch_name: ${{ inputs.panther_codebase_version }}
           build_type: ${{ inputs.build_type }}
           ros_distro: ${{ matrix.ros_distro }}
           platforms: ${{ matrix.platforms }}

--- a/.github/workflows/ros-docker-image.yaml
+++ b/.github/workflows/ros-docker-image.yaml
@@ -7,6 +7,8 @@ on:
       panther_codebase_version:
         description: Version of the panther_ros to be used in the docker image (branch/tag/commit).
         required: true
+        type: string
+        default: ros2-devel
       build_type:
         description: Is it a "development" or a "stable" release?
         required: true

--- a/Dockerfile.hardware
+++ b/Dockerfile.hardware
@@ -1,5 +1,6 @@
 ARG ROS_DISTRO=humble
 ARG BUILD_TEST=OFF
+ARG BRANCH_NAME=ros2-devel
 
 FROM husarnet/ros:${ROS_DISTRO}-ros-core
 
@@ -13,7 +14,7 @@ RUN apt-get update  && \
     apt-get install -y \
         ros-dev-tools && \
     # Setup workspace
-    git clone -b ros2-devel https://github.com/husarion/panther_ros.git src/panther_ros && \
+    git clone -b ${BRANCH_NAME} https://github.com/husarion/panther_ros.git src/panther_ros && \
     vcs import src < src/panther_ros/panther/panther_${HUSARION_ROS_BUILD_TYPE}.repos && \
     cp -r src/ros2_controllers/diff_drive_controller src && \
     cp -r src/ros2_controllers/imu_sensor_broadcaster src && \

--- a/Dockerfile.hardware
+++ b/Dockerfile.hardware
@@ -1,8 +1,9 @@
 ARG ROS_DISTRO=humble
-ARG BUILD_TEST=OFF
-ARG BRANCH_NAME=ros2-devel
 
 FROM husarnet/ros:${ROS_DISTRO}-ros-core
+
+ARG BRANCH_NAME=ros2-devel
+ARG BUILD_TEST=OFF
 
 ENV HUSARION_ROS_BUILD_TYPE=hardware
 

--- a/Dockerfile.simulation
+++ b/Dockerfile.simulation
@@ -1,5 +1,6 @@
 ARG ROS_DISTRO=humble
 ARG BUILD_TEST=OFF
+ARG BRANCH_NAME=ros2-devel
 
 FROM husarnet/ros:${ROS_DISTRO}-ros-core
 
@@ -13,7 +14,7 @@ RUN apt-get update  && \
     apt-get install -y \
         ros-dev-tools && \
     # Setup workspace
-    git clone -b ros2-devel https://github.com/husarion/panther_ros.git src/panther_ros && \
+    git clone -b ${BRANCH_NAME} https://github.com/husarion/panther_ros.git src/panther_ros && \
     vcs import src < src/panther_ros/panther/panther_${HUSARION_ROS_BUILD_TYPE}.repos && \
     cp -r src/ros2_controllers/diff_drive_controller src && \
     cp -r src/ros2_controllers/imu_sensor_broadcaster src && \

--- a/Dockerfile.simulation
+++ b/Dockerfile.simulation
@@ -1,8 +1,9 @@
 ARG ROS_DISTRO=humble
-ARG BUILD_TEST=OFF
-ARG BRANCH_NAME=ros2-devel
 
 FROM husarnet/ros:${ROS_DISTRO}-ros-core
+
+ARG BRANCH_NAME=ros2-devel
+ARG BUILD_TEST=OFF
 
 ENV HUSARION_ROS_BUILD_TYPE=simulation
 


### PR DESCRIPTION
### Changes

- Add new input to build the docker image workflow
- Parametrize the `panther_ros` branch in both Dockerfiles 