### PR TITLE
Add optional tag suffix on feature branches

### DIFF
--- a/.github/workflows/ros-docker-image.yaml
+++ b/.github/workflows/ros-docker-image.yaml
@@ -32,6 +32,11 @@ on:
           YYYYMMDD (eg. 20220124)
         type: string
         default: '20131206'
+      feature_branch_tag_suffix:
+        description: In case of "development" release from a feature branch specify the custom tag suffix
+          for the docker image
+        type: string
+        default: ''
 
 jobs:
   build:
@@ -53,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build Docker Image
-        uses: husarion-ci/ros-docker-img-action@v0.6
+        uses: husarion-ci/ros-docker-img-action@v0.7
         with:
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -64,7 +69,9 @@ jobs:
           build_type: ${{ inputs.build_type }}
           ros_distro: ${{ matrix.ros_distro }}
           platforms: ${{ matrix.platforms }}
-                  # variables important only for stable release
+          # variables important only for stable release
           target_distro: ${{ inputs.target_distro }}
           target_release: ${{ inputs.target_release }}
           target_date: ${{ inputs.target_date }}
+          # variables important only for development release
+          feature_branch_tag_suffix: ${{ inputs.feature_branch_tag_suffix }}


### PR DESCRIPTION
## Summary
Allow user to specify a custom suffix for feature branch builds. This change enables releasing multiple dev images from the same branch.

## Changes
- added new `feature_branch_tag_suffix` parameter